### PR TITLE
Fixed vusb.gif always showing up as changed.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.ico binary
 *.icns binary
 *.jar binary
+*.gif binary


### PR DESCRIPTION
# One-line summary
Fix vusb.gif showing up as changed

## Description
See summary

## Types of Changes
- Configuration change

## Tasks
Nothing else

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
